### PR TITLE
Update question route

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ const graphqlHTTP = require('express-graphql')
 
 const indexRouter = require('./routes/index');
 const schema  = require('./graphql/schema');
-const { getQuestions, createQuestion } = require('./graphql/resolvers.js');
+const { getQuestions, createQuestion, updateBody } = require('./graphql/resolvers.js');
 
 const app = express();
 
@@ -20,7 +20,8 @@ app.use('/', indexRouter);
 
 const root = {
   questions: getQuestions,
-  addQuestion: createQuestion
+  addQuestion: createQuestion,
+  updateQuestionBody: updateBody
 }
 app.use('/graphql', graphqlHTTP({
   schema: schema,

--- a/graphql/resolvers.js
+++ b/graphql/resolvers.js
@@ -7,7 +7,16 @@ module.exports = {
   },
 
   createQuestion: ({body}) => {
-    console.log(body)
     return Question.create({body: body})
+  },
+
+  updateBody: ({id, body}) => {
+    return Question.update(
+      { body },
+      { returning: true, where: { id }}
+    )
+    .then(updatedQuestion => {
+      return updatedQuestion[1][0]
+    })
   }
 };

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -19,5 +19,9 @@ module.exports = buildSchema(`
       body: String!
       active: Boolean
     ): Question!
+    updateQuestionBody(
+      id: Int!
+      body: String!
+    ): Question
   }
 `)

--- a/tests/graphql/create_question_request.spec.js
+++ b/tests/graphql/create_question_request.spec.js
@@ -24,7 +24,6 @@ describe('Mockr API', () => {
         .send(reqBody)
         .then(response => {
           expect(response.status).toBe(200)
-          console.log(response.body)
           expect(Object.keys(response.body.data.addQuestion)).toContain("id")
           expect(Object.keys(response.body.data.addQuestion)).toContain("body")
           expect(Object.keys(response.body.data.addQuestion)).toContain("active")

--- a/tests/graphql/update_question_request.spec.js
+++ b/tests/graphql/update_question_request.spec.js
@@ -1,0 +1,37 @@
+const shell = require('shelljs');
+const request = require('supertest');
+const app = require('../../app');
+const cleanup = require('../helpers/test_clear_database');
+const Question = require('../../models').Question;
+
+
+describe('Mockr API', () => {
+  describe('GraphQL update question mutation query', () => {
+    beforeEach(async () => {
+      await cleanup();
+    });
+
+    test('It returns the updated question', async () => {
+      let question = await Question.create({
+        body: "How does your past experiences help you become a better developer?",
+      });
+      let body = "Do you like writing tests?"
+      let reqBody = {
+        "query": `mutation {
+          updateQuestionBody(id:${question.id}, body: "${body}")
+          {id,body,active}
+        }`
+      };
+
+      return request(app)
+        .post('/graphql')
+        .send(reqBody)
+        .then(response => {
+          expect(response.status).toBe(200)
+          expect(Object.keys(response.body.data.updateQuestionBody)).toContain("id")
+          expect(Object.keys(response.body.data.updateQuestionBody)).toContain("active")
+          expect(response.body.data.updateQuestionBody.body).toBe("Do you like writing tests?")
+        })
+    })
+  })
+})


### PR DESCRIPTION
- Able to send a POST request to '/graphql' with query mutation updateQuestionBody(id, body) to receive an updated record.

- Closes [#18](https://github.com/eoneill23/mockr/issues/18)