### PR TITLE
Deactivate question route

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,12 @@ const graphqlHTTP = require('express-graphql')
 
 const indexRouter = require('./routes/index');
 const schema  = require('./graphql/schema');
-const { getQuestions, createQuestion, updateBody } = require('./graphql/resolvers.js');
+const { 
+  getQuestions, 
+  createQuestion, 
+  updateBody,
+  updateActive
+} = require('./graphql/resolvers.js');
 
 const app = express();
 
@@ -21,7 +26,8 @@ app.use('/', indexRouter);
 const root = {
   questions: getQuestions,
   addQuestion: createQuestion,
-  updateQuestionBody: updateBody
+  updateQuestionBody: updateBody,
+  deactivateQuestion: updateActive
 }
 app.use('/graphql', graphqlHTTP({
   schema: schema,

--- a/graphql/resolvers.js
+++ b/graphql/resolvers.js
@@ -18,5 +18,15 @@ module.exports = {
     .then(updatedQuestion => {
       return updatedQuestion[1][0]
     })
+  },
+
+  updateActive: ({id, active}) => {
+    return Question.update(
+      { active },
+      { returning: true, where: { id }}
+    )
+    .then(updatedQuestion => {
+      return updatedQuestion[1][0]
+    })
   }
 };

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -23,5 +23,9 @@ module.exports = buildSchema(`
       id: Int!
       body: String!
     ): Question
+    deactivateQuestion(
+      id: Int!
+      active: Boolean!
+    ): Question
   }
 `)

--- a/tests/graphql/deactivate_question_request.spec.js
+++ b/tests/graphql/deactivate_question_request.spec.js
@@ -1,0 +1,37 @@
+const shell = require('shelljs');
+const request = require('supertest');
+const app = require('../../app');
+const cleanup = require('../helpers/test_clear_database');
+const Question = require('../../models').Question;
+
+
+describe('Mockr API', () => {
+  describe('GraphQL deactivate question mutation query', () => {
+    beforeEach(async () => {
+      await cleanup();
+    });
+
+    test('It returns the updated question', async () => {
+      let question = await Question.create({
+        body: "How does your past experiences help you become a better developer?",
+      });
+      let reqBody = {
+        "query": `mutation {
+          deactivateQuestion(id:${question.id}, active: false)
+          {id,body,active}
+        }`
+      };
+
+      return request(app)
+        .post('/graphql')
+        .send(reqBody)
+        .then(response => {
+          expect(response.status).toBe(200)
+          console.log(response.body)
+          expect(Object.keys(response.body.data.deactivateQuestion)).toContain("id")
+          expect(Object.keys(response.body.data.deactivateQuestion)).toContain("active")
+          expect(response.body.data.deactivateQuestion.active).toBe(false)
+        })
+    })
+  })
+})


### PR DESCRIPTION
- Able to send POST request to '/graphql' with mutation query deactivateQuestion(id, active: boolean).

- Closes [#19](https://github.com/eoneill23/mockr/issues/19)