### PR TITLE
Activate question route

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,7 +27,8 @@ const root = {
   questions: getQuestions,
   addQuestion: createQuestion,
   updateQuestionBody: updateBody,
-  deactivateQuestion: updateActive
+  deactivateQuestion: updateActive,
+  activateQuestion: updateActive
 }
 app.use('/graphql', graphqlHTTP({
   schema: schema,

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -27,5 +27,9 @@ module.exports = buildSchema(`
       id: Int!
       active: Boolean!
     ): Question
+    activateQuestion(
+      id: Int!
+      active: Boolean!
+    ): Question
   }
 `)

--- a/tests/graphql/activate_question_request.spec.js
+++ b/tests/graphql/activate_question_request.spec.js
@@ -1,0 +1,37 @@
+const shell = require('shelljs');
+const request = require('supertest');
+const app = require('../../app');
+const cleanup = require('../helpers/test_clear_database');
+const Question = require('../../models').Question;
+
+
+describe('Mockr API', () => {
+  describe('GraphQL activate question mutation query', () => {
+    beforeEach(async () => {
+      await cleanup();
+    });
+
+    test('It returns the updated question', async () => {
+      let question = await Question.create({
+        body: "How does your past experiences help you become a better developer?",
+        active: false
+      });
+      let reqBody = {
+        "query": `mutation {
+          activateQuestion(id:${question.id}, active: true)
+          {id,body,active}
+        }`
+      };
+
+      return request(app)
+        .post('/graphql')
+        .send(reqBody)
+        .then(response => {
+          expect(response.status).toBe(200)
+          expect(Object.keys(response.body.data.activateQuestion)).toContain("id")
+          expect(Object.keys(response.body.data.activateQuestion)).toContain("active")
+          expect(response.body.data.activateQuestion.active).toBe(true)
+        })
+    })
+  })
+})

--- a/tests/graphql/deactivate_question_request.spec.js
+++ b/tests/graphql/deactivate_question_request.spec.js
@@ -27,7 +27,6 @@ describe('Mockr API', () => {
         .send(reqBody)
         .then(response => {
           expect(response.status).toBe(200)
-          console.log(response.body)
           expect(Object.keys(response.body.data.deactivateQuestion)).toContain("id")
           expect(Object.keys(response.body.data.deactivateQuestion)).toContain("active")
           expect(response.body.data.deactivateQuestion.active).toBe(false)


### PR DESCRIPTION
- Able to send a POST request to '/graphql' with query mutation activateQuestion(id, active: boolean) to receive an updated record.

- Closes [#20](https://github.com/eoneill23/mockr/issues/20)