### PR TITLE
Create interview route

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,7 +10,8 @@ const {
   getQuestions, 
   createQuestion, 
   updateBody,
-  updateActive
+  updateActive,
+  createInterview
 } = require('./graphql/resolvers.js');
 
 const app = express();
@@ -28,7 +29,8 @@ const root = {
   addQuestion: createQuestion,
   updateQuestionBody: updateBody,
   deactivateQuestion: updateActive,
-  activateQuestion: updateActive
+  activateQuestion: updateActive,
+  addInterview: createInterview
 }
 app.use('/graphql', graphqlHTTP({
   schema: schema,

--- a/graphql/resolvers.js
+++ b/graphql/resolvers.js
@@ -1,4 +1,7 @@
 const Question = require('../models').Question;
+const Interview = require('../models').Interview;
+const InterviewUser = require('../models').InterviewUser;
+const User = require('../models').User;
 const Sequelize = require('sequelize');
 
 module.exports = {
@@ -28,5 +31,32 @@ module.exports = {
     .then(updatedQuestion => {
       return updatedQuestion[1][0]
     })
+  },
+
+  createInterview: async ({studentId, interviewerId}) => {
+    return await Interview.create()
+      .then(async interview => {
+        await InterviewUser.create({
+          interviewId: interview.id,
+          userId: studentId
+        })
+        await InterviewUser.create({
+          interviewId: interview.id,
+          userId: interviewerId
+        })
+        return interview;
+      })
+      .then(interview => {
+        return Interview.findOne({
+          where: { id: interview.id },
+          include: [{
+            model: User,
+            as: 'users',
+            through: {
+              attributes: []
+            }
+          }]
+        })
+      })
   }
 };

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -6,6 +6,22 @@ module.exports = buildSchema(`
     body: String
     active: Boolean
   },
+  type Interview {
+    id: Int
+    score: Int
+    summary: String
+    users: [User]
+  },
+  type User {
+    id: Int
+    firstName: String
+    lastName: String
+    email: String
+    password: String
+    program: String
+    cohort: Int
+    role: Int
+  }
   type Query {
     questions(
       id: Int
@@ -31,5 +47,9 @@ module.exports = buildSchema(`
       id: Int!
       active: Boolean!
     ): Question
+    addInterview(
+      studentId: Int!
+      interviewerId: Int!
+    ): Interview!
   }
 `)

--- a/migrations/20191022220923-create-user.js
+++ b/migrations/20191022220923-create-user.js
@@ -1,0 +1,45 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('Users', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      firstName: {
+        type: Sequelize.STRING
+      },
+      lastName: {
+        type: Sequelize.STRING
+      },
+      email: {
+        type: Sequelize.STRING
+      },
+      password: {
+        type: Sequelize.STRING
+      },
+      program: {
+        type: Sequelize.STRING
+      },
+      cohort: {
+        type: Sequelize.INTEGER
+      },
+      role: {
+        type: Sequelize.INTEGER
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('Users');
+  }
+};

--- a/migrations/20191022222448-create-interview.js
+++ b/migrations/20191022222448-create-interview.js
@@ -1,0 +1,30 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('Interviews', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      score: {
+        type: Sequelize.INTEGER
+      },
+      summary: {
+        type: Sequelize.STRING
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('Interviews');
+  }
+};

--- a/migrations/20191022230929-create-interview-user.js
+++ b/migrations/20191022230929-create-interview-user.js
@@ -1,0 +1,30 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('InterviewUsers', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      interviewId: {
+        type: Sequelize.INTEGER
+      },
+      userId: {
+        type: Sequelize.INTEGER
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('InterviewUsers');
+  }
+};

--- a/models/interview.js
+++ b/models/interview.js
@@ -1,0 +1,15 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const Interview = sequelize.define('Interview', {
+    score: DataTypes.INTEGER,
+    summary: DataTypes.STRING
+  }, {});
+  Interview.associate = function(models) {
+    Interview.belongsToMany(models.User, {
+      through: 'InterviewUsers',
+      as: 'users',
+      foreignKey: 'interviewId'
+    })
+  };
+  return Interview;
+};

--- a/models/interviewuser.js
+++ b/models/interviewuser.js
@@ -1,0 +1,24 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const InterviewUser = sequelize.define('InterviewUser', {
+    interviewId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Interviews',
+        key: 'id'
+      }
+    }, 
+    userId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Users',
+        key: 'id'
+      }
+    }
+  }, {});
+  InterviewUser.associate = function(models) {
+  };
+  return InterviewUser;
+};

--- a/models/user.js
+++ b/models/user.js
@@ -1,0 +1,20 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const User = sequelize.define('User', {
+    firstName: DataTypes.STRING,
+    lastName: DataTypes.STRING,
+    email: DataTypes.STRING,
+    password: DataTypes.STRING,
+    program: DataTypes.STRING,
+    cohort: DataTypes.INTEGER,
+    role: DataTypes.INTEGER
+  }, {});
+  User.associate = function(models) {
+    User.belongsToMany(models.Interview, {
+      through: 'InterviewUsers',
+      as: 'interviews',
+      foreignKey: 'userId'
+    })
+  };
+  return User;
+};

--- a/tests/graphql/create_interview_request.spec.js
+++ b/tests/graphql/create_interview_request.spec.js
@@ -1,0 +1,66 @@
+const shell = require('shelljs');
+const request = require('supertest');
+const app = require('../../app');
+const cleanup = require('../helpers/test_clear_database');
+const Interview = require('../../models').Interview;
+const User = require('../../models').User;
+
+describe('Mockr API', () => {
+  describe('Create interview POST request', () => {
+    beforeEach(async () => {
+      await cleanup();
+    });
+
+    test('It returns the created question', async () => {
+      let student = await User.create({ 
+        firstName: 'Wayne',
+        lastName: 'Brady',
+        email: 'waynebrady@turing.io',
+        password: '12345',
+        program: 'BE',
+        cohort: 1904,
+        role: 0
+      })
+      let interviewer = await User.create({ 
+        firstName: 'Ian',
+        lastName: 'Douglas',
+        email: 'iandouglas@turing.io',
+        password: '12345',
+        program: 'BE',
+        cohort: 1801,
+        role: 1
+      })
+      let reqBody = {
+        "query": `mutation {
+          addInterview(studentId:${student.id}, interviewerId:${interviewer.id})
+          {
+            id,
+            score,
+            summary,
+            users {
+              id,
+              firstName,
+              lastName,
+              email,
+              program, 
+              cohort,
+              role
+            }
+          }
+        }`
+      };
+
+      return request(app)
+        .post('/graphql')
+        .send(reqBody)
+        .then(response => {
+          expect(response.status).toBe(200)
+          expect(Object.keys(response.body.data.addInterview)).toContain("id")
+          expect(Object.keys(response.body.data.addInterview)).toContain("score")
+          expect(Object.keys(response.body.data.addInterview)).toContain("summary")
+          expect(Object.keys(response.body.data.addInterview)).toContain("users")
+          expect(response.body.data.addInterview.users.length).toEqual(2)
+        })
+    })
+  })
+})

--- a/tests/helpers/test_clear_database.js
+++ b/tests/helpers/test_clear_database.js
@@ -1,5 +1,9 @@
 const Question = require('../../models').Question;
+const Interview = require('../../models').Interview;
+const User = require('../../models').User;
 
 module.exports = async function cleanup() {
   await Question.destroy({ where: {} })
+  await Interview.destroy({ where: {} })
+  await User.destroy({ where: {} })
 }


### PR DESCRIPTION
- Able to send a POST request to '/graphql' with mutation query addInterview(studentId, interviewerId) to receive created interview and associated users.

- Closes [#21](https://github.com/eoneill23/mockr/issues/21)