### PR TITLE
Add user query route

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,24 +19,13 @@ const {
   getRandomQuestions,
   editNote,
   getInterview,
-  createSession
+  createSession,
+  createUser
 } = require('./graphql/resolvers.js');
-
 
 const app = express();
 const FormatError = require('easygraphql-format-error');
-const formatError = new FormatError([
-  {
-    name: 'INVALID_EMAIL',
-    message: 'The email or password is not valid',
-    statusCode: '400'
-  },
-  {
-    name: 'INVALID_PASSWORD',
-    message: 'The email or password is not valid',
-    statusCode: '400'
-  }
-]);
+const formatError = new FormatError();
 const errorName = formatError.errorName;
 
 app.use(cors());
@@ -62,7 +51,8 @@ const root = {
   randomQuestions: getRandomQuestions,
   updateNote: editNote,
   interview: getInterview,
-  login: createSession
+  login: createSession,
+  addUser: createUser
 }
 app.use('/graphql', graphqlHTTP({
   schema: schema,

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -100,5 +100,14 @@ module.exports = buildSchema(`
       score: Int
       body: String
     ): Note!
+    addUser(
+      firstName: String!
+      lastName: String!
+      email: String!
+      password: String!
+      passwordConfirmation: String!
+      program: String
+      cohort: Int
+    ): User
   }
 `)

--- a/migrations/20191022220923-create-user.js
+++ b/migrations/20191022220923-create-user.js
@@ -15,7 +15,8 @@ module.exports = {
         type: Sequelize.STRING
       },
       email: {
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
+        isEmail: true
       },
       password: {
         type: Sequelize.STRING
@@ -27,7 +28,8 @@ module.exports = {
         type: Sequelize.INTEGER
       },
       role: {
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
+        defaultValue: 0
       },
       createdAt: {
         allowNull: false,

--- a/tests/graphql/create_user_request.spec.js
+++ b/tests/graphql/create_user_request.spec.js
@@ -1,0 +1,121 @@
+const shell = require('shelljs');
+const request = require('supertest');
+const app = require('../../app');
+const cleanup = require('../helpers/test_clear_database');
+
+describe('Mockr API', () => {
+  describe('addUser query request', () => {
+    beforeEach(async () => {
+      await cleanup();
+    });
+
+    test('It returns the created user', async () => {
+      let reqBody1 = {
+        "query": `mutation {
+          addUser(
+            firstName: "Sejin"
+            lastName: "Kim"
+            email: "sejthewedge@gmail.com"
+            password: "password"
+            passwordConfirmation: "password"
+            program: "BE"
+            cohort: 1904
+          ) {
+            id
+            firstName
+            lastName
+            email
+            program
+            cohort
+            role
+          }
+        }`
+      };
+
+      let reqBody2 = {
+        "query": `mutation {
+          addUser(
+            firstName: "Sejin"
+            lastName: "Kim"
+            email: "sejthewedge@gmail.com"
+            password: "password"
+            passwordConfirmation: "pasdsword"
+            program: "BE"
+            cohort: 1904
+          ) {
+            id
+            firstName
+            lastName
+            email
+            program
+            cohort
+            role
+          }
+        }`
+      };
+
+      let reqBody3 = {
+        "query": `mutation {
+          addUser(
+            firstName: "Sejin"
+            lastName: "Kim"
+            email: "sejthewedgegmail.com"
+            password: "password"
+            passwordConfirmation: "pasdsword"
+            program: "BE"
+            cohort: 1904
+          ) {
+            id
+            firstName
+            lastName
+            email
+            program
+            cohort
+            role
+          }
+        }`
+      };
+
+      await request(app)
+        .post('/graphql')
+        .send(reqBody1)
+        .then(response => {
+          expect(response.status).toBe(200)
+          expect(Object.keys(response.body.data.addUser)).toContain("id")
+          expect(Object.keys(response.body.data.addUser)).toContain("firstName")
+          expect(Object.keys(response.body.data.addUser)).toContain("lastName")
+          expect(Object.keys(response.body.data.addUser)).toContain("email")
+          expect(Object.keys(response.body.data.addUser)).toContain("program")
+          expect(Object.keys(response.body.data.addUser)).toContain("cohort")
+          expect(Object.keys(response.body.data.addUser)).toContain("role")
+        })
+
+      await request(app)
+        .post('/graphql')
+        .send(reqBody2)
+        .then(response => {
+          expect(response.status).toBe(200)
+          expect(Object.keys(response.body)).toContain("errors")
+          expect(Object.keys(response.body.errors[0])).toContain("message")
+        })
+
+      await request(app)
+        .post('/graphql')
+        .send(reqBody3)
+        .then(response => {
+          expect(response.status).toBe(200)
+          expect(Object.keys(response.body)).toContain("errors")
+          expect(Object.keys(response.body.errors[0])).toContain("message")
+        })
+
+      return await request(app)
+        .post('/graphql')
+        .send(reqBody1)
+        .then(response => {
+          expect(response.status).toBe(200)
+          expect(Object.keys(response.body)).toContain("errors")
+          expect(Object.keys(response.body.errors[0])).toContain("message")
+        })
+    })
+  })
+})


### PR DESCRIPTION
- Able to send POST request to '/graphql' with query mutation 
addUser(firstName, lastName, email, password, passwordConfirmation, program, cohort) 
to receive created user.
- Sad paths tested
- Closes [#60](https://github.com/eoneill23/mockr/issues/60)